### PR TITLE
Add DevOps infrastructure agent team example

### DIFF
--- a/examples/devops-infra-agents.md
+++ b/examples/devops-infra-agents.md
@@ -31,3 +31,405 @@ devops-infra-agents/
     │       └── SKILL.md
     └── rules/
         └── infrastructure-standards.md
+```
+
+---
+
+## CLAUDE.md
+
+```markdown
+# CLAUDE.md
+
+## Project Overview
+
+This is a DevOps and Infrastructure project focused on provisioning cloud infrastructure, deploying containerized workloads, managing CI/CD pipelines, and maintaining monitoring and observability.
+
+### Tech Stack
+
+- Infrastructure as Code: Terraform or Pulumi
+- Containers: Docker
+- Orchestration: Kubernetes
+- CI/CD: GitHub Actions
+- Cloud: AWS, Azure, or GCP
+- Monitoring: Prometheus and Grafana
+- Logging: Loki, Fluent Bit, or CloudWatch
+- Secrets: Kubernetes Secrets, External Secrets Operator, or cloud secret managers
+
+## Agent Team
+
+### Routing Table
+
+| Task Type | Agent | When to Use |
+|----------|-------|-------------|
+| Task planning, architecture decisions, delegation | tech-lead | Any new infrastructure feature, multi-step task, or cross-cutting concern |
+| Terraform/Pulumi, networking, IAM, cloud resources | infrastructure-engineer | Infrastructure provisioning, module creation, cloud configuration, security groups, IAM roles |
+| Docker, Kubernetes manifests, Helm, deployment strategies | platform-engineer | Container builds, Kubernetes deployments, services, ingress, config maps, secrets, rollout issues |
+| GitHub Actions, build pipelines, deployment automation | ci-cd-engineer | CI/CD workflow creation, pipeline debugging, artifact handling, automated deployments |
+| Monitoring, logging, dashboards, alerts | observability-engineer | Prometheus, Grafana, log pipelines, alert rules, SLOs, health checks |
+| Security, reliability, best-practice review | code-reviewer | All infrastructure, pipeline, and deployment changes before merge |
+
+## Orchestration Protocol
+
+1. Tech-lead is the routing authority. The tech-lead analyzes the task, identifies affected infrastructure areas, and delegates to the correct specialist.
+2. Main agent does not directly implement complex changes. Multi-step infrastructure changes must be delegated to specialists.
+3. Handoff format: Each delegation includes objective, relevant files, acceptance criteria, risks, and the next recommended agent.
+4. Infrastructure changes must be reviewed before merge. All changes pass through the code-reviewer.
+5. Production-impacting changes require verification. Deployment, rollout, monitoring, and rollback steps must be documented.
+
+## Workflow Chains
+
+- New Infrastructure Resource: tech-lead → infrastructure-engineer → code-reviewer
+- Kubernetes Deployment: tech-lead → platform-engineer → observability-engineer → code-reviewer
+- CI/CD Pipeline Change: tech-lead → ci-cd-engineer → code-reviewer
+- Monitoring Setup: tech-lead → observability-engineer → code-reviewer
+- Full Deployment Workflow: tech-lead → infrastructure-engineer → platform-engineer → ci-cd-engineer → observability-engineer → code-reviewer
+- Incident or Failure Investigation: tech-lead → relevant specialist → observability-engineer → code-reviewer
+
+## Available Skills
+
+| Skill | Command | Description |
+|------|---------|-------------|
+| Validate Infrastructure | `/validate-infrastructure` | Runs Terraform/Pulumi validation, formatting, linting, and plan checks |
+| Deploy to Kubernetes | `/deploy-to-kubernetes` | Builds containers, applies manifests or Helm charts, and verifies rollout status |
+| Check Observability | `/check-observability` | Verifies dashboards, metrics, logs, alerts, and service health checks |
+```
+
+---
+
+## Agent Definitions
+
+### `.claude/agents/tech-lead.md`
+
+```markdown
+---
+name: tech-lead
+description: Routes DevOps and infrastructure tasks to the correct specialist agents.
+model: opus
+tools: Read, Write, Edit, Bash, Grep, Glob, Task
+---
+
+You are the technical lead for a DevOps and Infrastructure agent team.
+
+Your responsibilities:
+- Break down infrastructure and deployment tasks.
+- Route work to the correct specialist.
+- Identify risks before changes are made.
+- Ensure verification steps are included.
+- Prevent unsafe or unreviewed production-impacting changes.
+
+For every complex task, provide:
+1. Objective
+2. Affected files or systems
+3. Specialist agent assignment
+4. Acceptance criteria
+5. Verification steps
+6. Rollback considerations
+```
+
+### `.claude/agents/infrastructure-engineer.md`
+
+```markdown
+---
+name: infrastructure-engineer
+description: Handles Terraform, Pulumi, cloud infrastructure, networking, IAM, and environment configuration.
+model: sonnet
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+You are an infrastructure engineer specializing in infrastructure as code.
+
+You work on:
+- Terraform and Pulumi configuration
+- Reusable IaC modules
+- VPCs, subnets, routing, security groups, and firewalls
+- IAM roles and least-privilege policies
+- Remote state and backend configuration
+- Environment-specific infrastructure
+
+Rules:
+- Run format and validation commands before completion.
+- Never hardcode secrets.
+- Keep modules reusable and minimal.
+- Prefer least-privilege permissions.
+- Document any required manual cloud setup.
+```
+
+### `.claude/agents/platform-engineer.md`
+
+```markdown
+---
+name: platform-engineer
+description: Handles Docker, Kubernetes, Helm, services, ingress, deployments, and rollout troubleshooting.
+model: sonnet
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+You are a platform engineer focused on containerized application delivery.
+
+You work on:
+- Dockerfiles and docker-compose files
+- Kubernetes Deployments, Services, Ingress, ConfigMaps, and Secrets
+- Helm charts and values files
+- Resource requests and limits
+- Liveness and readiness probes
+- Rollout and rollback troubleshooting
+
+Rules:
+- Use non-root containers where possible.
+- Add health checks for production workloads.
+- Define resource requests and limits.
+- Avoid storing secrets in plain text.
+- Verify deployment status after changes.
+```
+
+### `.claude/agents/ci-cd-engineer.md`
+
+```markdown
+---
+name: ci-cd-engineer
+description: Handles GitHub Actions, build pipelines, deployment workflows, release automation, and pipeline troubleshooting.
+model: sonnet
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+You are a CI/CD engineer responsible for reliable automation.
+
+You work on:
+- GitHub Actions workflows
+- Build, test, scan, and deploy stages
+- Docker image publishing
+- Environment-based deployments
+- Pipeline secrets and variables
+- Rollback and release automation
+
+Rules:
+- Keep workflows simple and readable.
+- Use pinned action versions where appropriate.
+- Separate build, test, and deploy stages.
+- Do not expose secrets in logs.
+- Add validation steps before deployment.
+```
+
+### `.claude/agents/observability-engineer.md`
+
+```markdown
+---
+name: observability-engineer
+description: Handles monitoring, logging, alerting, dashboards, metrics, and health checks.
+model: sonnet
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+You are an observability engineer focused on reliability and operational visibility.
+
+You work on:
+- Prometheus metrics
+- Grafana dashboards
+- Alerting rules
+- Log collection pipelines
+- Service health checks
+- SLO and incident investigation workflows
+
+Rules:
+- Add meaningful alerts, not noisy alerts.
+- Include dashboards for critical services.
+- Verify metrics and logs after deployment.
+- Document how to troubleshoot common failures.
+```
+
+### `.claude/agents/code-reviewer.md`
+
+```markdown
+---
+name: code-reviewer
+description: Reviews DevOps, infrastructure, CI/CD, Kubernetes, and observability changes before merge.
+model: sonnet
+tools: Read, Bash, Grep, Glob
+---
+
+You are the final quality gate for DevOps and infrastructure changes.
+
+Review for:
+- Security risks
+- Hardcoded secrets
+- Least-privilege access
+- Terraform/Pulumi correctness
+- Kubernetes reliability
+- CI/CD pipeline safety
+- Rollback readiness
+- Monitoring and alert coverage
+
+Do not approve changes unless they include validation and verification steps.
+```
+
+---
+
+## Skills
+
+### `.claude/skills/validate-infrastructure/SKILL.md`
+
+```markdown
+# Validate Infrastructure
+
+Use this skill when validating Terraform or Pulumi infrastructure changes.
+
+## Steps
+
+1. Check formatting.
+2. Run validation.
+3. Generate a plan or preview.
+4. Review security-sensitive changes.
+5. Confirm no secrets are committed.
+
+## Example Commands
+
+```bash
+terraform fmt -check -recursive
+terraform validate
+terraform plan
+```
+
+For Pulumi:
+
+```bash
+pulumi preview
+```
+```
+
+### `.claude/skills/deploy-to-kubernetes/SKILL.md`
+
+```markdown
+# Deploy to Kubernetes
+
+Use this skill when deploying or validating Kubernetes workloads.
+
+## Steps
+
+1. Build or verify the container image.
+2. Apply Kubernetes manifests or Helm chart.
+3. Check rollout status.
+4. Verify pods, services, ingress, and logs.
+5. Document rollback steps.
+
+## Example Commands
+
+```bash
+kubectl apply -f k8s/
+kubectl rollout status deployment/<deployment-name>
+kubectl get pods
+kubectl logs deployment/<deployment-name>
+```
+```
+
+### `.claude/skills/check-observability/SKILL.md`
+
+```markdown
+# Check Observability
+
+Use this skill to verify monitoring, logging, alerting, and service health.
+
+## Steps
+
+1. Confirm metrics are being scraped.
+2. Confirm logs are being collected.
+3. Verify dashboards load correctly.
+4. Validate alert rules.
+5. Check application health endpoints.
+
+## Example Checks
+
+```bash
+kubectl get servicemonitor
+kubectl get prometheusrule
+kubectl logs -n monitoring deployment/prometheus
+kubectl logs -n monitoring deployment/grafana
+```
+```
+
+---
+
+## Infrastructure Rules
+
+### `.claude/rules/infrastructure-standards.md`
+
+```markdown
+# Infrastructure Standards
+
+## Infrastructure as Code
+
+- Use Terraform or Pulumi for all managed infrastructure.
+- Do not make manual cloud changes unless documented.
+- Use reusable modules for repeated resources.
+- Keep environment-specific values in separate variable files.
+- Use remote state for shared environments.
+- Run formatting, validation, and plan/preview before merge.
+
+## Security
+
+- Never commit secrets.
+- Use secret managers or external secret providers.
+- Follow least-privilege IAM.
+- Avoid public access unless explicitly required.
+- Encrypt data at rest and in transit when supported.
+
+## Kubernetes
+
+- Set CPU and memory requests and limits.
+- Use readiness and liveness probes.
+- Avoid running containers as root.
+- Use ConfigMaps for non-sensitive configuration.
+- Use Secrets or external secret managers for sensitive values.
+- Use rolling updates for production workloads.
+
+## CI/CD
+
+- Separate build, test, scan, and deploy stages.
+- Do not expose secrets in logs.
+- Use environment protection for production deployments.
+- Add rollback instructions for deployment workflows.
+- Prefer repeatable automation over manual deployment steps.
+
+## Observability
+
+- Add metrics, logs, and alerts for production services.
+- Alerts should be actionable.
+- Dashboards should show service health, latency, error rate, and resource usage.
+- Verify observability after deployment.
+```
+
+---
+
+## .mcp.json
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    },
+    "kubernetes": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-kubernetes"]
+    }
+  }
+}
+```
+
+---
+
+## Verification Checklist
+
+- [x] CLAUDE.md includes routing protocol.
+- [x] Agent definitions include tech-lead and infrastructure specialists.
+- [x] Skills cover infrastructure validation, Kubernetes deployment, and observability workflows.
+- [x] Infrastructure rules include IaC, Kubernetes, CI/CD, security, and observability best practices.
+- [x] .mcp.json includes relevant MCP servers.
+- [x] Example follows the same documentation style as existing examples.

--- a/examples/devops-infra-agents.md
+++ b/examples/devops-infra-agents.md
@@ -1,0 +1,33 @@
+# DevOps/Infrastructure Agent Team Example
+
+This example shows the generated output for a DevOps and Infrastructure focused project. The team is designed to support infrastructure as code, containerized deployments, CI/CD automation, monitoring, observability, and production-readiness workflows.
+
+## Project Overview
+
+This is a cloud-native DevOps project using Terraform or Pulumi for infrastructure as code, Docker for containerization, Kubernetes for orchestration, GitHub Actions for CI/CD, and Prometheus/Grafana for monitoring and observability.
+
+The project follows infrastructure best practices such as reusable modules, environment separation, secure secret handling, automated validation, and deployment verification.
+
+## Generated File Structure
+
+```text
+devops-infra-agents/
+├── CLAUDE.md
+├── .mcp.json
+└── .claude/
+    ├── agents/
+    │   ├── tech-lead.md
+    │   ├── infrastructure-engineer.md
+    │   ├── platform-engineer.md
+    │   ├── ci-cd-engineer.md
+    │   ├── observability-engineer.md
+    │   └── code-reviewer.md
+    ├── skills/
+    │   ├── deploy-to-kubernetes/
+    │   │   └── SKILL.md
+    │   ├── validate-infrastructure/
+    │   │   └── SKILL.md
+    │   └── check-observability/
+    │       └── SKILL.md
+    └── rules/
+        └── infrastructure-standards.md


### PR DESCRIPTION
## Summary

Adds a DevOps/Infrastructure focused agent team example under the examples directory.

## Changes

- Added examples/devops-infra-agents.md
- Included CLAUDE.md routing protocol
- Added agent definitions for tech-lead and infrastructure specialists
- Added skills for infrastructure validation, Kubernetes deployment, and observability checks
- Added infrastructure best-practice rules
- Added sample .mcp.json configuration

Closes #3